### PR TITLE
Updated version of terraform provider to v1.0.3

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.2
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20250530111747-935112552988
 
 require (
-	github.com/deltastreaminc/terraform-provider-deltastream v1.0.2
+	github.com/deltastreaminc/terraform-provider-deltastream v1.0.3
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.110.0
 	github.com/pulumi/pulumi/sdk/v3 v3.175.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -334,8 +334,8 @@ github.com/deckarep/golang-set/v2 v2.5.0 h1:hn6cEZtQ0h3J8kFrHR/NrzyOoTnjgW1+FmNJ
 github.com/deckarep/golang-set/v2 v2.5.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/deltastreaminc/go-deltastream v0.0.0-20250418175217-32cf93339bc4 h1:dvzFQdJrSmgdWsoSO+8cHdgKrOGgfpQPFxxJF/iXuoM=
 github.com/deltastreaminc/go-deltastream v0.0.0-20250418175217-32cf93339bc4/go.mod h1:1V6VqCpZ2tzO1IJ0BJ0ttg/RF+eYjxjmJ/zyIQVDJV0=
-github.com/deltastreaminc/terraform-provider-deltastream v1.0.2 h1:8gYHiDxdrXlPtDZROuuuRXUjlKMS+L3QN54uWXjvoro=
-github.com/deltastreaminc/terraform-provider-deltastream v1.0.2/go.mod h1:ydd0hE+X0rA1ytGgGKe7uUMAt/D8akmMzEGzIOSazxU=
+github.com/deltastreaminc/terraform-provider-deltastream v1.0.3 h1:tZKFEX1INbiOIDRtvmcgP6Pr8Sfav824Z7kIbEMvOBw=
+github.com/deltastreaminc/terraform-provider-deltastream v1.0.3/go.mod h1:ydd0hE+X0rA1ytGgGKe7uUMAt/D8akmMzEGzIOSazxU=
 github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
 github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
 github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=


### PR DESCRIPTION
We were experiencing issues with Snowflake table creation, so the Terraform provider was updated to allow CREATE TABLE operations specifically for Snowflake. Therefore, we need to update the provider version here to use the latest changes.