### PR TITLE
provider: skip DESCRIBE re-validation in Check when SQL is unchanged

### DIFF
--- a/provider/application.go
+++ b/provider/application.go
@@ -99,6 +99,13 @@ func (Application) Check(ctx context.Context, req infer.CheckRequest) (infer.Che
 		return infer.CheckResponse[ApplicationArgs]{Inputs: args, Failures: failures}, nil
 	}
 
+	// Skip DESCRIBE when SQL is unchanged from the prior deploy. This prevents re-validating
+	// stale RESUME FROM QUERY ID references that may have been garbage-collected by the server
+	// while the application is still running correctly.
+	if oldVal, ok := req.OldInputs.GetOk("sql"); ok && oldVal.IsString() && oldVal.AsString() == args.SQL {
+		return infer.CheckResponse[ApplicationArgs]{Inputs: args, Failures: failures}, nil
+	}
+
 	cfg := infer.GetConfig[Config](ctx)
 	db, oerr := openDB(ctx, &cfg)
 	if oerr != nil { // tolerate missing connection in preview

--- a/provider/application.go
+++ b/provider/application.go
@@ -99,10 +99,15 @@ func (Application) Check(ctx context.Context, req infer.CheckRequest) (infer.Che
 		return infer.CheckResponse[ApplicationArgs]{Inputs: args, Failures: failures}, nil
 	}
 
-	// Skip DESCRIBE when SQL is unchanged from the prior deploy. This prevents re-validating
-	// stale RESUME FROM QUERY ID references that may have been garbage-collected by the server
-	// while the application is still running correctly.
-	if oldVal, ok := req.OldInputs.GetOk("sql"); ok && oldVal.IsString() && oldVal.AsString() == args.SQL {
+	// Skip DESCRIBE when all relevant inputs (sql, sinks, sources) are unchanged from the
+	// prior deploy. This prevents re-validating stale RESUME FROM QUERY ID references that
+	// may have been garbage-collected while the application is still running correctly.
+	// We decode OldInputs to include sinkRelationFqns and sourceRelationFqns in the
+	// comparison so that user changes to those fields always trigger re-validation.
+	if oldArgs, _, oerr := infer.DefaultCheck[ApplicationArgs](ctx, req.OldInputs); oerr == nil &&
+		oldArgs.SQL == args.SQL &&
+		stringSlicesEqual(oldArgs.SinkRelationFqns, args.SinkRelationFqns) &&
+		stringSlicesEqual(oldArgs.SourceRelationFqns, args.SourceRelationFqns) {
 		return infer.CheckResponse[ApplicationArgs]{Inputs: args, Failures: failures}, nil
 	}
 

--- a/provider/application_test.go
+++ b/provider/application_test.go
@@ -1,0 +1,135 @@
+// Copyright 2025, DeltaStream Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+// TestApplicationCheck_SkipsDescribeWhenSQLUnchanged verifies that Application.Check returns no
+// failures and does not attempt to open a DB connection when the SQL is identical to the prior
+// deploy (OldInputs["sql"] == new SQL). This prevents spurious failures caused by stale
+// RESUME FROM QUERY ID references that have been garbage-collected after 30 days.
+func TestApplicationCheck_SkipsDescribeWhenSQLUnchanged(t *testing.T) {
+	t.Parallel()
+
+	const sql = `BEGIN APPLICATION myapp
+  INSERT INTO "db"."schema"."sink" SELECT * FROM "db"."schema"."src";
+END APPLICATION WITH (resume.from.query.id = '0fe1f533-0d9d-4250-8841-8ffc47af4d71');`
+
+	tests := []struct {
+		name            string
+		oldSQL          string // empty means no OldInputs["sql"] key
+		newSQL          string
+		wantSkip        bool // true → no failures expected (DESCRIBE skipped)
+		sources         []string
+		sinks           []string
+	}{
+		{
+			name:     "unchanged SQL skips DESCRIBE",
+			oldSQL:   sql,
+			newSQL:   sql,
+			wantSkip: true,
+			sources:  []string{`"db"."schema"."src"`},
+			sinks:    []string{`"db"."schema"."sink"`},
+		},
+		{
+			name:     "no OldInputs (first create) does not skip",
+			oldSQL:   "",
+			newSQL:   sql,
+			wantSkip: false,
+			sources:  []string{`"db"."schema"."src"`},
+			sinks:    []string{`"db"."schema"."sink"`},
+		},
+		{
+			name:     "changed SQL does not skip",
+			oldSQL:   sql + " -- modified",
+			newSQL:   sql,
+			wantSkip: false,
+			sources:  []string{`"db"."schema"."src"`},
+			sinks:    []string{`"db"."schema"."sink"`},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			oldInputs := property.Map{}
+			if tt.oldSQL != "" {
+				oldInputs = property.NewMap(map[string]property.Value{
+					"sql": property.New(tt.oldSQL),
+				})
+			}
+
+			newInputs := property.NewMap(map[string]property.Value{
+				"sql":                property.New(tt.newSQL),
+				"sourceRelationFqns": property.New(property.NewArray(func() []property.Value {
+					vals := make([]property.Value, len(tt.sources))
+					for i, s := range tt.sources {
+						vals[i] = property.New(s)
+					}
+					return vals
+				}())),
+				"sinkRelationFqns": property.New(property.NewArray(func() []property.Value {
+					vals := make([]property.Value, len(tt.sinks))
+					for i, s := range tt.sinks {
+						vals[i] = property.New(s)
+					}
+					return vals
+				}())),
+			})
+
+			if tt.wantSkip {
+				// When SQL is unchanged the provider must return no failures without
+				// reaching the DB (no DB credentials are set so any DB attempt would fail).
+				resp, err := Application{}.Check(context.Background(), infer.CheckRequest{
+					OldInputs: oldInputs,
+					NewInputs: newInputs,
+				})
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if len(resp.Failures) != 0 {
+					t.Errorf("expected no failures when SQL unchanged, got: %v", resp.Failures)
+				}
+			} else {
+				// When SQL changes or OldInputs is absent the provider proceeds past the guard
+				// and attempts to open a DB connection (which panics or errors without a
+				// provider context). A panic here confirms that DESCRIBE was not skipped.
+				panicked := func() (p bool) {
+					defer func() {
+						if r := recover(); r != nil {
+							p = true
+						}
+					}()
+					_, _ = Application{}.Check(context.Background(), infer.CheckRequest{
+						OldInputs: oldInputs,
+						NewInputs: newInputs,
+					})
+					return false
+				}()
+				if !panicked {
+					t.Error("expected DB access (panic) when SQL is changed or new, but Check returned without error")
+				}
+			}
+		})
+	}
+}

--- a/provider/application_test.go
+++ b/provider/application_test.go
@@ -22,48 +22,67 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
-// TestApplicationCheck_SkipsDescribeWhenSQLUnchanged verifies that Application.Check returns no
-// failures and does not attempt to open a DB connection when the SQL is identical to the prior
-// deploy (OldInputs["sql"] == new SQL). This prevents spurious failures caused by stale
-// RESUME FROM QUERY ID references that have been garbage-collected after 30 days.
-func TestApplicationCheck_SkipsDescribeWhenSQLUnchanged(t *testing.T) {
+// TestApplicationCheck_SkipsDescribeWhenInputsUnchanged verifies that Application.Check returns
+// no failures and does not attempt a DB connection when all inputs (SQL, sinks, sources) match
+// the prior deploy. This prevents spurious failures from stale RESUME FROM QUERY ID references
+// that have been garbage-collected after 30 days while the application is still running.
+func TestApplicationCheck_SkipsDescribeWhenInputsUnchanged(t *testing.T) {
 	t.Parallel()
 
 	const sql = `BEGIN APPLICATION myapp
   INSERT INTO "db"."schema"."sink" SELECT * FROM "db"."schema"."src";
 END APPLICATION WITH (resume.from.query.id = '0fe1f533-0d9d-4250-8841-8ffc47af4d71');`
 
+	const src = `"db"."schema"."src"`
+	const sink = `"db"."schema"."sink"`
+
+	buildInputs := func(sqlStr string, sources, sinks []string) property.Map {
+		srcVals := make([]property.Value, len(sources))
+		for i, s := range sources {
+			srcVals[i] = property.New(s)
+		}
+		sinkVals := make([]property.Value, len(sinks))
+		for i, s := range sinks {
+			sinkVals[i] = property.New(s)
+		}
+		return property.NewMap(map[string]property.Value{
+			"sql":                property.New(sqlStr),
+			"sourceRelationFqns": property.New(property.NewArray(srcVals)),
+			"sinkRelationFqns":   property.New(property.NewArray(sinkVals)),
+		})
+	}
+
+	newInputs := buildInputs(sql, []string{src}, []string{sink})
+
 	tests := []struct {
-		name            string
-		oldSQL          string // empty means no OldInputs["sql"] key
-		newSQL          string
-		wantSkip        bool // true → no failures expected (DESCRIBE skipped)
-		sources         []string
-		sinks           []string
+		name      string
+		oldInputs property.Map
+		wantSkip  bool
 	}{
 		{
-			name:     "unchanged SQL skips DESCRIBE",
-			oldSQL:   sql,
-			newSQL:   sql,
-			wantSkip: true,
-			sources:  []string{`"db"."schema"."src"`},
-			sinks:    []string{`"db"."schema"."sink"`},
+			name:      "all inputs unchanged skips DESCRIBE",
+			oldInputs: buildInputs(sql, []string{src}, []string{sink}),
+			wantSkip:  true,
 		},
 		{
-			name:     "no OldInputs (first create) does not skip",
-			oldSQL:   "",
-			newSQL:   sql,
-			wantSkip: false,
-			sources:  []string{`"db"."schema"."src"`},
-			sinks:    []string{`"db"."schema"."sink"`},
+			name:      "no OldInputs (first create) does not skip",
+			oldInputs: property.Map{},
+			wantSkip:  false,
 		},
 		{
-			name:     "changed SQL does not skip",
-			oldSQL:   sql + " -- modified",
-			newSQL:   sql,
-			wantSkip: false,
-			sources:  []string{`"db"."schema"."src"`},
-			sinks:    []string{`"db"."schema"."sink"`},
+			name:      "changed SQL does not skip",
+			oldInputs: buildInputs(sql+" -- modified", []string{src}, []string{sink}),
+			wantSkip:  false,
+		},
+		{
+			name:      "SQL same but sinks changed does not skip",
+			oldInputs: buildInputs(sql, []string{src}, []string{`"db"."schema"."old_sink"`}),
+			wantSkip:  false,
+		},
+		{
+			name:      "SQL same but sources changed does not skip",
+			oldInputs: buildInputs(sql, []string{`"db"."schema"."old_src"`}, []string{sink}),
+			wantSkip:  false,
 		},
 	}
 
@@ -72,48 +91,23 @@ END APPLICATION WITH (resume.from.query.id = '0fe1f533-0d9d-4250-8841-8ffc47af4d
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			oldInputs := property.Map{}
-			if tt.oldSQL != "" {
-				oldInputs = property.NewMap(map[string]property.Value{
-					"sql": property.New(tt.oldSQL),
-				})
-			}
-
-			newInputs := property.NewMap(map[string]property.Value{
-				"sql":                property.New(tt.newSQL),
-				"sourceRelationFqns": property.New(property.NewArray(func() []property.Value {
-					vals := make([]property.Value, len(tt.sources))
-					for i, s := range tt.sources {
-						vals[i] = property.New(s)
-					}
-					return vals
-				}())),
-				"sinkRelationFqns": property.New(property.NewArray(func() []property.Value {
-					vals := make([]property.Value, len(tt.sinks))
-					for i, s := range tt.sinks {
-						vals[i] = property.New(s)
-					}
-					return vals
-				}())),
-			})
-
 			if tt.wantSkip {
-				// When SQL is unchanged the provider must return no failures without
-				// reaching the DB (no DB credentials are set so any DB attempt would fail).
+				// When all inputs are unchanged the provider must return no failures without
+				// reaching the DB (no credentials configured so any DB attempt would fail).
 				resp, err := Application{}.Check(context.Background(), infer.CheckRequest{
-					OldInputs: oldInputs,
+					OldInputs: tt.oldInputs,
 					NewInputs: newInputs,
 				})
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
 				if len(resp.Failures) != 0 {
-					t.Errorf("expected no failures when SQL unchanged, got: %v", resp.Failures)
+					t.Errorf("expected no failures when inputs unchanged, got: %v", resp.Failures)
 				}
 			} else {
-				// When SQL changes or OldInputs is absent the provider proceeds past the guard
-				// and attempts to open a DB connection (which panics or errors without a
-				// provider context). A panic here confirms that DESCRIBE was not skipped.
+				// When inputs change or OldInputs is absent the provider proceeds past the
+				// guard and attempts to open a DB connection, which panics without a provider
+				// context. A panic here confirms DESCRIBE was not skipped.
 				panicked := func() (p bool) {
 					defer func() {
 						if r := recover(); r != nil {
@@ -121,13 +115,13 @@ END APPLICATION WITH (resume.from.query.id = '0fe1f533-0d9d-4250-8841-8ffc47af4d
 						}
 					}()
 					_, _ = Application{}.Check(context.Background(), infer.CheckRequest{
-						OldInputs: oldInputs,
+						OldInputs: tt.oldInputs,
 						NewInputs: newInputs,
 					})
 					return false
 				}()
 				if !panicked {
-					t.Error("expected DB access (panic) when SQL is changed or new, but Check returned without error")
+					t.Error("expected DB access (panic) when inputs changed or new, but Check returned without error")
 				}
 			}
 		})

--- a/provider/application_test.go
+++ b/provider/application_test.go
@@ -34,6 +34,7 @@ func TestApplicationCheck_SkipsDescribeWhenInputsUnchanged(t *testing.T) {
 END APPLICATION WITH (resume.from.query.id = '0fe1f533-0d9d-4250-8841-8ffc47af4d71');`
 
 	const src = `"db"."schema"."src"`
+	const src2 = `"db"."schema"."src2"`
 	const sink = `"db"."schema"."sink"`
 
 	buildInputs := func(sqlStr string, sources, sinks []string) property.Map {
@@ -52,36 +53,46 @@ END APPLICATION WITH (resume.from.query.id = '0fe1f533-0d9d-4250-8841-8ffc47af4d
 		})
 	}
 
-	newInputs := buildInputs(sql, []string{src}, []string{sink})
-
 	tests := []struct {
 		name      string
 		oldInputs property.Map
+		newInputs property.Map
 		wantSkip  bool
 	}{
 		{
 			name:      "all inputs unchanged skips DESCRIBE",
 			oldInputs: buildInputs(sql, []string{src}, []string{sink}),
+			newInputs: buildInputs(sql, []string{src}, []string{sink}),
+			wantSkip:  true,
+		},
+		{
+			name:      "sources in different order still skips (order-insensitive)",
+			oldInputs: buildInputs(sql, []string{src2, src}, []string{sink}),
+			newInputs: buildInputs(sql, []string{src, src2}, []string{sink}),
 			wantSkip:  true,
 		},
 		{
 			name:      "no OldInputs (first create) does not skip",
 			oldInputs: property.Map{},
+			newInputs: buildInputs(sql, []string{src}, []string{sink}),
 			wantSkip:  false,
 		},
 		{
 			name:      "changed SQL does not skip",
 			oldInputs: buildInputs(sql+" -- modified", []string{src}, []string{sink}),
+			newInputs: buildInputs(sql, []string{src}, []string{sink}),
 			wantSkip:  false,
 		},
 		{
 			name:      "SQL same but sinks changed does not skip",
 			oldInputs: buildInputs(sql, []string{src}, []string{`"db"."schema"."old_sink"`}),
+			newInputs: buildInputs(sql, []string{src}, []string{sink}),
 			wantSkip:  false,
 		},
 		{
 			name:      "SQL same but sources changed does not skip",
 			oldInputs: buildInputs(sql, []string{`"db"."schema"."old_src"`}, []string{sink}),
+			newInputs: buildInputs(sql, []string{src}, []string{sink}),
 			wantSkip:  false,
 		},
 	}
@@ -96,7 +107,7 @@ END APPLICATION WITH (resume.from.query.id = '0fe1f533-0d9d-4250-8841-8ffc47af4d
 				// reaching the DB (no credentials configured so any DB attempt would fail).
 				resp, err := Application{}.Check(context.Background(), infer.CheckRequest{
 					OldInputs: tt.oldInputs,
-					NewInputs: newInputs,
+					NewInputs: tt.newInputs,
 				})
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
@@ -116,7 +127,7 @@ END APPLICATION WITH (resume.from.query.id = '0fe1f533-0d9d-4250-8841-8ffc47af4d
 					}()
 					_, _ = Application{}.Check(context.Background(), infer.CheckRequest{
 						OldInputs: tt.oldInputs,
-						NewInputs: newInputs,
+						NewInputs: tt.newInputs,
 					})
 					return false
 				}()

--- a/provider/query.go
+++ b/provider/query.go
@@ -102,10 +102,15 @@ func (Query) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckResp
 		return infer.CheckResponse[QueryArgs]{Inputs: args, Failures: failures}, nil
 	}
 
-	// Skip DESCRIBE when SQL is unchanged from the prior deploy. This prevents re-validating
-	// stale RESUME FROM QUERY ID references that may have been garbage-collected by the server
-	// while the query is still running correctly.
-	if oldVal, ok := req.OldInputs.GetOk("sql"); ok && oldVal.IsString() && oldVal.AsString() == args.SQL {
+	// Skip DESCRIBE when all relevant inputs (sql, sink, sources) are unchanged from the
+	// prior deploy. This prevents re-validating stale RESUME FROM QUERY ID references that
+	// may have been garbage-collected while the query is still running correctly.
+	// We decode OldInputs to include sinkRelationFqn and sourceRelationFqns in the
+	// comparison so that user changes to those fields always trigger re-validation.
+	if oldArgs, _, oerr := infer.DefaultCheck[QueryArgs](ctx, req.OldInputs); oerr == nil &&
+		oldArgs.SQL == args.SQL &&
+		oldArgs.SinkRelationFqn == args.SinkRelationFqn &&
+		stringSlicesEqual(oldArgs.SourceRelationFqns, args.SourceRelationFqns) {
 		return infer.CheckResponse[QueryArgs]{Inputs: args, Failures: failures}, nil
 	}
 

--- a/provider/query.go
+++ b/provider/query.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -175,13 +176,20 @@ func (Query) Diff(ctx context.Context, req infer.DiffRequest[QueryArgs, QuerySta
 	return infer.DiffResponse{HasChanges: len(diff) > 0, DetailedDiff: diff, DeleteBeforeReplace: true}, nil
 }
 
-// stringSlicesEqual returns true if slices have identical length and element order.
+// stringSlicesEqual returns true if the two slices contain the same elements regardless of
+// order. Copies are sorted before comparison so the originals are not mutated.
 func stringSlicesEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}
-	for i := range a {
-		if a[i] != b[i] {
+	ac := make([]string, len(a))
+	bc := make([]string, len(b))
+	copy(ac, a)
+	copy(bc, b)
+	slices.Sort(ac)
+	slices.Sort(bc)
+	for i := range ac {
+		if ac[i] != bc[i] {
 			return false
 		}
 	}

--- a/provider/query.go
+++ b/provider/query.go
@@ -101,6 +101,14 @@ func (Query) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckResp
 	if args.SQL == "" || args.SinkRelationFqn == "" || len(args.SourceRelationFqns) == 0 {
 		return infer.CheckResponse[QueryArgs]{Inputs: args, Failures: failures}, nil
 	}
+
+	// Skip DESCRIBE when SQL is unchanged from the prior deploy. This prevents re-validating
+	// stale RESUME FROM QUERY ID references that may have been garbage-collected by the server
+	// while the query is still running correctly.
+	if oldVal, ok := req.OldInputs.GetOk("sql"); ok && oldVal.IsString() && oldVal.AsString() == args.SQL {
+		return infer.CheckResponse[QueryArgs]{Inputs: args, Failures: failures}, nil
+	}
+
 	cfg := infer.GetConfig[Config](ctx)
 	db, oerr := openDB(ctx, &cfg)
 	if oerr != nil { // tolerate missing connection in preview

--- a/provider/query_test.go
+++ b/provider/query_test.go
@@ -22,46 +22,60 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
-// TestQueryCheck_SkipsDescribeWhenSQLUnchanged verifies that Query.Check returns no failures
-// and does not attempt to open a DB connection when the SQL is identical to the prior deploy
-// (OldInputs["sql"] == new SQL). This is consistent with the same guard in Application.Check
-// and guards against future additions of resume-style clauses in INSERT INTO queries.
-func TestQueryCheck_SkipsDescribeWhenSQLUnchanged(t *testing.T) {
+// TestQueryCheck_SkipsDescribeWhenInputsUnchanged verifies that Query.Check returns no failures
+// and does not attempt a DB connection when all inputs (SQL, sink, sources) match the prior
+// deploy. This mirrors the same guard in Application.Check and guards against future additions
+// of resume-style clauses in INSERT INTO queries.
+func TestQueryCheck_SkipsDescribeWhenInputsUnchanged(t *testing.T) {
 	t.Parallel()
 
 	const sql = `INSERT INTO "db"."schema"."sink" SELECT * FROM "db"."schema"."src";`
+	const src = `"db"."schema"."src"`
+	const sink = `"db"."schema"."sink"`
+
+	buildInputs := func(sqlStr, sinkFqn string, sources []string) property.Map {
+		srcVals := make([]property.Value, len(sources))
+		for i, s := range sources {
+			srcVals[i] = property.New(s)
+		}
+		return property.NewMap(map[string]property.Value{
+			"sql":                property.New(sqlStr),
+			"sinkRelationFqn":    property.New(sinkFqn),
+			"sourceRelationFqns": property.New(property.NewArray(srcVals)),
+		})
+	}
+
+	newInputs := buildInputs(sql, sink, []string{src})
 
 	tests := []struct {
-		name     string
-		oldSQL   string // empty means no OldInputs["sql"] key
-		newSQL   string
-		wantSkip bool
-		sources  []string
-		sink     string
+		name      string
+		oldInputs property.Map
+		wantSkip  bool
 	}{
 		{
-			name:     "unchanged SQL skips DESCRIBE",
-			oldSQL:   sql,
-			newSQL:   sql,
-			wantSkip: true,
-			sources:  []string{`"db"."schema"."src"`},
-			sink:     `"db"."schema"."sink"`,
+			name:      "all inputs unchanged skips DESCRIBE",
+			oldInputs: buildInputs(sql, sink, []string{src}),
+			wantSkip:  true,
 		},
 		{
-			name:     "no OldInputs (first create) does not skip",
-			oldSQL:   "",
-			newSQL:   sql,
-			wantSkip: false,
-			sources:  []string{`"db"."schema"."src"`},
-			sink:     `"db"."schema"."sink"`,
+			name:      "no OldInputs (first create) does not skip",
+			oldInputs: property.Map{},
+			wantSkip:  false,
 		},
 		{
-			name:     "changed SQL does not skip",
-			oldSQL:   sql + " -- modified",
-			newSQL:   sql,
-			wantSkip: false,
-			sources:  []string{`"db"."schema"."src"`},
-			sink:     `"db"."schema"."sink"`,
+			name:      "changed SQL does not skip",
+			oldInputs: buildInputs(sql+" -- modified", sink, []string{src}),
+			wantSkip:  false,
+		},
+		{
+			name:      "SQL same but sink changed does not skip",
+			oldInputs: buildInputs(sql, `"db"."schema"."old_sink"`, []string{src}),
+			wantSkip:  false,
+		},
+		{
+			name:      "SQL same but sources changed does not skip",
+			oldInputs: buildInputs(sql, sink, []string{`"db"."schema"."old_src"`}),
+			wantSkip:  false,
 		},
 	}
 
@@ -70,40 +84,23 @@ func TestQueryCheck_SkipsDescribeWhenSQLUnchanged(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			oldInputs := property.Map{}
-			if tt.oldSQL != "" {
-				oldInputs = property.NewMap(map[string]property.Value{
-					"sql": property.New(tt.oldSQL),
-				})
-			}
-
-			newInputs := property.NewMap(map[string]property.Value{
-				"sql": property.New(tt.newSQL),
-				"sourceRelationFqns": property.New(property.NewArray(func() []property.Value {
-					vals := make([]property.Value, len(tt.sources))
-					for i, s := range tt.sources {
-						vals[i] = property.New(s)
-					}
-					return vals
-				}())),
-				"sinkRelationFqn": property.New(tt.sink),
-			})
-
 			if tt.wantSkip {
+				// When all inputs are unchanged the provider must return no failures without
+				// reaching the DB (no credentials configured so any DB attempt would fail).
 				resp, err := Query{}.Check(context.Background(), infer.CheckRequest{
-					OldInputs: oldInputs,
+					OldInputs: tt.oldInputs,
 					NewInputs: newInputs,
 				})
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
 				if len(resp.Failures) != 0 {
-					t.Errorf("expected no failures when SQL unchanged, got: %v", resp.Failures)
+					t.Errorf("expected no failures when inputs unchanged, got: %v", resp.Failures)
 				}
 			} else {
-				// When SQL changes or OldInputs is absent the provider proceeds past the guard
-				// and attempts to open a DB connection (which panics without a provider context).
-				// A panic here confirms that DESCRIBE was not skipped.
+				// When inputs change or OldInputs is absent the provider proceeds past the
+				// guard and attempts to open a DB connection, which panics without a provider
+				// context. A panic here confirms DESCRIBE was not skipped.
 				panicked := func() (p bool) {
 					defer func() {
 						if r := recover(); r != nil {
@@ -111,13 +108,13 @@ func TestQueryCheck_SkipsDescribeWhenSQLUnchanged(t *testing.T) {
 						}
 					}()
 					_, _ = Query{}.Check(context.Background(), infer.CheckRequest{
-						OldInputs: oldInputs,
+						OldInputs: tt.oldInputs,
 						NewInputs: newInputs,
 					})
 					return false
 				}()
 				if !panicked {
-					t.Error("expected DB access (panic) when SQL is changed or new, but Check returned without error")
+					t.Error("expected DB access (panic) when inputs changed or new, but Check returned without error")
 				}
 			}
 		})

--- a/provider/query_test.go
+++ b/provider/query_test.go
@@ -31,6 +31,7 @@ func TestQueryCheck_SkipsDescribeWhenInputsUnchanged(t *testing.T) {
 
 	const sql = `INSERT INTO "db"."schema"."sink" SELECT * FROM "db"."schema"."src";`
 	const src = `"db"."schema"."src"`
+	const src2 = `"db"."schema"."src2"`
 	const sink = `"db"."schema"."sink"`
 
 	buildInputs := func(sqlStr, sinkFqn string, sources []string) property.Map {
@@ -45,36 +46,46 @@ func TestQueryCheck_SkipsDescribeWhenInputsUnchanged(t *testing.T) {
 		})
 	}
 
-	newInputs := buildInputs(sql, sink, []string{src})
-
 	tests := []struct {
 		name      string
 		oldInputs property.Map
+		newInputs property.Map
 		wantSkip  bool
 	}{
 		{
 			name:      "all inputs unchanged skips DESCRIBE",
 			oldInputs: buildInputs(sql, sink, []string{src}),
+			newInputs: buildInputs(sql, sink, []string{src}),
+			wantSkip:  true,
+		},
+		{
+			name:      "sources in different order still skips (order-insensitive)",
+			oldInputs: buildInputs(sql, sink, []string{src2, src}),
+			newInputs: buildInputs(sql, sink, []string{src, src2}),
 			wantSkip:  true,
 		},
 		{
 			name:      "no OldInputs (first create) does not skip",
 			oldInputs: property.Map{},
+			newInputs: buildInputs(sql, sink, []string{src}),
 			wantSkip:  false,
 		},
 		{
 			name:      "changed SQL does not skip",
 			oldInputs: buildInputs(sql+" -- modified", sink, []string{src}),
+			newInputs: buildInputs(sql, sink, []string{src}),
 			wantSkip:  false,
 		},
 		{
 			name:      "SQL same but sink changed does not skip",
 			oldInputs: buildInputs(sql, `"db"."schema"."old_sink"`, []string{src}),
+			newInputs: buildInputs(sql, sink, []string{src}),
 			wantSkip:  false,
 		},
 		{
 			name:      "SQL same but sources changed does not skip",
 			oldInputs: buildInputs(sql, sink, []string{`"db"."schema"."old_src"`}),
+			newInputs: buildInputs(sql, sink, []string{src}),
 			wantSkip:  false,
 		},
 	}
@@ -89,7 +100,7 @@ func TestQueryCheck_SkipsDescribeWhenInputsUnchanged(t *testing.T) {
 				// reaching the DB (no credentials configured so any DB attempt would fail).
 				resp, err := Query{}.Check(context.Background(), infer.CheckRequest{
 					OldInputs: tt.oldInputs,
-					NewInputs: newInputs,
+					NewInputs: tt.newInputs,
 				})
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
@@ -109,7 +120,7 @@ func TestQueryCheck_SkipsDescribeWhenInputsUnchanged(t *testing.T) {
 					}()
 					_, _ = Query{}.Check(context.Background(), infer.CheckRequest{
 						OldInputs: tt.oldInputs,
-						NewInputs: newInputs,
+						NewInputs: tt.newInputs,
 					})
 					return false
 				}()

--- a/provider/query_test.go
+++ b/provider/query_test.go
@@ -1,0 +1,125 @@
+// Copyright 2025, DeltaStream Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+// TestQueryCheck_SkipsDescribeWhenSQLUnchanged verifies that Query.Check returns no failures
+// and does not attempt to open a DB connection when the SQL is identical to the prior deploy
+// (OldInputs["sql"] == new SQL). This is consistent with the same guard in Application.Check
+// and guards against future additions of resume-style clauses in INSERT INTO queries.
+func TestQueryCheck_SkipsDescribeWhenSQLUnchanged(t *testing.T) {
+	t.Parallel()
+
+	const sql = `INSERT INTO "db"."schema"."sink" SELECT * FROM "db"."schema"."src";`
+
+	tests := []struct {
+		name     string
+		oldSQL   string // empty means no OldInputs["sql"] key
+		newSQL   string
+		wantSkip bool
+		sources  []string
+		sink     string
+	}{
+		{
+			name:     "unchanged SQL skips DESCRIBE",
+			oldSQL:   sql,
+			newSQL:   sql,
+			wantSkip: true,
+			sources:  []string{`"db"."schema"."src"`},
+			sink:     `"db"."schema"."sink"`,
+		},
+		{
+			name:     "no OldInputs (first create) does not skip",
+			oldSQL:   "",
+			newSQL:   sql,
+			wantSkip: false,
+			sources:  []string{`"db"."schema"."src"`},
+			sink:     `"db"."schema"."sink"`,
+		},
+		{
+			name:     "changed SQL does not skip",
+			oldSQL:   sql + " -- modified",
+			newSQL:   sql,
+			wantSkip: false,
+			sources:  []string{`"db"."schema"."src"`},
+			sink:     `"db"."schema"."sink"`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			oldInputs := property.Map{}
+			if tt.oldSQL != "" {
+				oldInputs = property.NewMap(map[string]property.Value{
+					"sql": property.New(tt.oldSQL),
+				})
+			}
+
+			newInputs := property.NewMap(map[string]property.Value{
+				"sql": property.New(tt.newSQL),
+				"sourceRelationFqns": property.New(property.NewArray(func() []property.Value {
+					vals := make([]property.Value, len(tt.sources))
+					for i, s := range tt.sources {
+						vals[i] = property.New(s)
+					}
+					return vals
+				}())),
+				"sinkRelationFqn": property.New(tt.sink),
+			})
+
+			if tt.wantSkip {
+				resp, err := Query{}.Check(context.Background(), infer.CheckRequest{
+					OldInputs: oldInputs,
+					NewInputs: newInputs,
+				})
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if len(resp.Failures) != 0 {
+					t.Errorf("expected no failures when SQL unchanged, got: %v", resp.Failures)
+				}
+			} else {
+				// When SQL changes or OldInputs is absent the provider proceeds past the guard
+				// and attempts to open a DB connection (which panics without a provider context).
+				// A panic here confirms that DESCRIBE was not skipped.
+				panicked := func() (p bool) {
+					defer func() {
+						if r := recover(); r != nil {
+							p = true
+						}
+					}()
+					_, _ = Query{}.Check(context.Background(), infer.CheckRequest{
+						OldInputs: oldInputs,
+						NewInputs: newInputs,
+					})
+					return false
+				}()
+				if !panicked {
+					t.Error("expected DB access (panic) when SQL is changed or new, but Check returned without error")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`Application.Check` (and `Query.Check`) call `DESCRIBE <sql>` on every `pulumi preview` / `pulumi up`, even when the resource's SQL has not changed. When the SQL contains a `RESUME FROM QUERY ID = '<uuid>'` clause, DeltaStream validates that the referenced query ID exists live on every check.

After 30 days the referenced query is garbage-collected, causing every subsequent preview to fail with:

```
has a problem: describe failed: no state available for query 0fe1f533-...
```

This error fires even though the Application itself has no pending changes, blocking unrelated changes in the same stack.

## Fix

In both `Application.Check` and `Query.Check`, after parsing the new inputs, compare `req.OldInputs["sql"]` to the new `args.SQL`. If they match, return immediately with no failures — bypassing the `DESCRIBE` call.

The guard is bypassed on first create (`OldInputs` is empty) and when the SQL actually changes, so full validation still runs whenever the SQL differs.

## Changes

- `provider/application.go` — skip `describeApplication` in `Application.Check` when SQL is unchanged
- `provider/query.go` — skip `describeQuery` in `Query.Check` when SQL is unchanged
- `provider/application_test.go` *(new)* — unit tests covering all three paths
- `provider/query_test.go` *(new)* — unit tests covering all three paths