### PR TITLE
fix: schema diff fallback and pulumi-package-publisher artifact format

### DIFF
--- a/.github/workflows/build_sdk.yml
+++ b/.github/workflows/build_sdk.yml
@@ -73,3 +73,20 @@ jobs:
           name: sdk-${{ matrix.language }}
           path: sdk/${{ matrix.language }}/
           retention-days: 7
+
+      # pulumi/pulumi-package-publisher (used by publish.yml for nodejs/python/dotnet/java)
+      # expects a same-run artifact literally named "<lang>-sdk.tar.gz" whose contents are a
+      # single "<lang>.tar.gz" tarball of the built SDK directory - see
+      # https://github.com/pulumi/pulumi-package-publisher#use. Go is published separately via
+      # pulumi/publish-go-sdk-action against the sdk-go artifact above, so it's excluded here.
+      - name: Package SDK for pulumi-package-publisher (${{ matrix.language }})
+        if: matrix.language != 'go'
+        run: tar -czf ${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
+
+      - name: Upload pulumi-package-publisher artifact (${{ matrix.language }})
+        if: matrix.language != 'go'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.language }}-sdk.tar.gz
+          path: ${{ matrix.language }}.tar.gz
+          retention-days: 7

--- a/.github/workflows/prerequisites.yml
+++ b/.github/workflows/prerequisites.yml
@@ -73,11 +73,33 @@ jobs:
             echo "SCHEMA_CHANGES<<$EOF"
             LAST=$(gh release view --json tagName -q .tagName 2>/dev/null || echo "NONE")
             if [ "$LAST" != "NONE" ]; then
-              schema-tools compare \
-                --provider deltastream \
-                --old-commit "$LAST" \
-                --repository github://api.github.com/deltastreaminc \
-                --new-path provider/cmd/pulumi-resource-deltastream/schema.json || true
+              # schema-tools compare --old-commit always fetches from the hardcoded
+              # provider/cmd/pulumi-resource-deltastream/schema.json path. That path only
+              # exists from #61 (2026-07-01) onward; releases at or before v0.4.3 still have
+              # schema.json at the repo root. Probe both locations so the diff keeps working
+              # for old-commit refs from either side of that move. Kept in sync with the
+              # equivalent step in publish.yml.
+              OLD_SCHEMA=""
+              for candidate in \
+                "provider/cmd/pulumi-resource-deltastream/schema.json" \
+                "schema.json"; do
+                if gh api -H "Accept: application/vnd.github.raw" \
+                     "repos/${{ github.repository }}/contents/${candidate}?ref=${LAST}" \
+                     > old-schema.json 2>/dev/null; then
+                  OLD_SCHEMA="old-schema.json"
+                  break
+                fi
+              done
+              if [ -n "$OLD_SCHEMA" ]; then
+                if ! schema-tools compare \
+                       --provider deltastream \
+                       --old-path "$OLD_SCHEMA" \
+                       --new-path provider/cmd/pulumi-resource-deltastream/schema.json; then
+                  echo "_Schema diff unavailable: \`schema-tools compare\` failed against previous release \`$LAST\`._"
+                fi
+              else
+                echo "_Schema diff unavailable: could not fetch schema.json for previous release \`$LAST\`._"
+              fi
             else
               echo "No previous release found; skipping schema diff."
             fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,11 +65,32 @@ jobs:
             echo "summary<<$EOF"
             LAST=$(gh release view --json tagName -q .tagName 2>/dev/null || echo "NONE")
             if [ "$LAST" != "NONE" ]; then
-              schema-tools compare \
-                --provider deltastream \
-                --old-commit "$LAST" \
-                --repository github://api.github.com/deltastreaminc \
-                --new-path dist/schema.json || true
+              # schema-tools compare --old-commit always fetches from the hardcoded
+              # provider/cmd/pulumi-resource-deltastream/schema.json path. That path only
+              # exists from #61 (2026-07-01) onward; releases at or before v0.4.3 still have
+              # schema.json at the repo root. Probe both locations so the diff keeps working
+              # for old-commit refs from either side of that move.
+              OLD_SCHEMA=""
+              for candidate in \
+                "provider/cmd/pulumi-resource-deltastream/schema.json" \
+                "schema.json"; do
+                if gh api -H "Accept: application/vnd.github.raw" \
+                     "repos/${{ github.repository }}/contents/${candidate}?ref=${LAST}" \
+                     > old-schema.json 2>/dev/null; then
+                  OLD_SCHEMA="old-schema.json"
+                  break
+                fi
+              done
+              if [ -n "$OLD_SCHEMA" ]; then
+                if ! schema-tools compare \
+                       --provider deltastream \
+                       --old-path "$OLD_SCHEMA" \
+                       --new-path dist/schema.json; then
+                  echo "_Schema diff unavailable: \`schema-tools compare\` failed against previous release \`$LAST\`._"
+                fi
+              else
+                echo "_Schema diff unavailable: could not fetch schema.json for previous release \`$LAST\`._"
+              fi
             fi
             echo "$EOF"
           } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
publish.yml: schema-tools compare --old-commit always fetches from the hardcoded provider/cmd/pulumi-resource-deltastream/schema.json path, which only exists from #61 (2026-07-01) onward. The latest release, v0.4.3, predates that move and still has schema.json at the repo root, so the "Compute schema diff summary" step 404'd and silently dropped the schema diff from release notes (masked by the trailing || true). Fetch the old schema.json ourselves, probing both locations, and pass it to schema-tools via --old-path instead of --old-commit.

build_sdk.yml: pulumi/pulumi-package-publisher expects same-run artifacts literally named "<lang>-sdk.tar.gz" containing a single "<lang>.tar.gz" tarball of the built SDK directory (nodejs/python/ dotnet/java). We only uploaded "sdk-<lang>" artifacts with the raw uncompressed directory, so "Publish all language SDKs" failed with "Artifact not found for name: nodejs-sdk.tar.gz" (and would have failed identically for python and dotnet). Package and upload the SDK in the format pulumi-package-publisher requires, alongside the existing sdk-<lang> artifact still used by the Go SDK reconstruction and integration tests.