### PR TITLE
fix: publish Go SDK from its actual module root (sdk/go/pulumi-deltastream)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -178,17 +178,21 @@ jobs:
           # PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           # PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
 
+      # go.mod for this SDK is generated (see Makefile: `go mod init
+      # $(PROJECT)/sdk/go/pulumi-$(PACK)`) at sdk/go/pulumi-deltastream, not at
+      # the sdk/ root. publish-go-sdk-action tags/validates the module using
+      # exactly `{repository}/{path}`, so source and path must point directly
+      # at the directory containing go.mod for `go get` to resolve correctly.
       - name: Publish Go SDK
         if: inputs.skipGoSdk == false
         uses: pulumi/publish-go-sdk-action@v1
         with:
           repository: ${{ github.repository }}
           base-ref: ${{ github.sha }}
-          source: sdk
-          path: sdk
+          source: sdk/go/pulumi-deltastream
+          path: sdk/go/pulumi-deltastream
           version: ${{ inputs.version }}
           additive: false
           files: |
-            go.*
-            go/**
+            **
             !*.tar.gz


### PR DESCRIPTION
## Problem

Every Go SDK release since #61 has been broken: `go get github.com/deltastreaminc/pulumi-deltastream/sdk@vX.Y.Z` fails with

```
go: module github.com/deltastreaminc/pulumi-deltastream@vX.Y.Z found, but does not contain package .../sdk
```

Confirmed via CI run [29368193418/job/87215300816](https://github.com/deltastreaminc/pulumi-deltastream/actions/runs/29368193418/job/87215300816) and reproduced locally:

```
$ go get github.com/deltastreaminc/pulumi-deltastream/sdk@v1.0.0-rc.4
go: module github.com/deltastreaminc/pulumi-deltastream@v1.0.0-rc.4 found, but does not contain package .../sdk
```

## Root cause

`pulumi/publish-go-sdk-action` tags/validates the module using exactly `{repository}/{path}` — it copies `source` into `path`, tags the result `{path}/v{version}`, then runs `go get github.com/{repository}/{path}@v{version}`. Whatever ends up at `path` root after copying must contain `go.mod`.

This repo's Go SDK `go.mod` actually lives at `sdk/go/pulumi-deltastream/go.mod` (module `github.com/deltastreaminc/pulumi-deltastream/sdk/go/pulumi-deltastream`), per the Makefile's `go mod init $(PROJECT)/sdk/go/pulumi-$(PACK)`. But the workflow was configured with `source: sdk` / `path: sdk`, so publishing copied the nested go.mod two directories too deep, leaving no `go.mod` at the tagged root (`sdk`). `go get .../sdk@version` then fell through to the unrelated repo-root `go.mod` and failed.

This was introduced by #61 (multi-language provider build), which moved Go SDK codegen into `sdk/go/pulumi-deltastream/` without updating this workflow to match. Older `sdk/v0.1.x` tags (pre-#61) still resolve fine — confirmed:

```
$ go get github.com/deltastreaminc/pulumi-deltastream/sdk@v0.1.6
go: added github.com/deltastreaminc/pulumi-deltastream/sdk v0.1.6
```

## Fix

Point `source`/`path` directly at `sdk/go/pulumi-deltastream`, so `go.mod` ends up at the tagged root:

```yaml
source: sdk/go/pulumi-deltastream
path: sdk/go/pulumi-deltastream
```

The published tag becomes `sdk/go/pulumi-deltastream/v{version}`, and the Go import path for consumers becomes:

```
go get github.com/deltastreaminc/pulumi-deltastream/sdk/go/pulumi-deltastream@vX.Y.Z
```

matching the module path already baked into the generated code.

## Note

This changes the intended public Go import path (the old `.../sdk` path never actually worked on any post-#61 release, so there's no working consumer to break).
