### PR TITLE
fix: publish .NET SDK as DeltaStream.Pulumi instead of Pulumi.DeltaStream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,10 +202,16 @@ generate_dotnet: .make/generate_dotnet
 	# namespace/filename, not from language.csharp.packageName above, so pin
 	# it explicitly here to avoid publishing under the reserved "Pulumi.*"
 	# NuGet ID prefix (owned by pulumi-bot).
-	@csproj=$$(find sdk/dotnet -maxdepth 1 -name '*.csproj'); \
-		grep -q '<PackageId>' "$$csproj" || \
-		sed -i.bak 's#<GeneratePackageOnBuild>true</GeneratePackageOnBuild>#<GeneratePackageOnBuild>true</GeneratePackageOnBuild>\n    <PackageId>DeltaStream.Pulumi</PackageId>#' "$$csproj" && \
-		rm -f "$$csproj.bak"
+	@count=$$(find sdk/dotnet -maxdepth 1 -name '*.csproj' | wc -l | tr -d ' '); \
+		if [ "$$count" -ne 1 ]; then \
+			echo "generate_dotnet: expected exactly one .csproj in sdk/dotnet, found $$count" >&2; \
+			exit 1; \
+		fi; \
+		csproj=$$(find sdk/dotnet -maxdepth 1 -name '*.csproj'); \
+		if ! grep -q '<PackageId>' "$$csproj"; then \
+			awk '{ print } /<GeneratePackageOnBuild>true<\/GeneratePackageOnBuild>/ && !done { print "    <PackageId>DeltaStream.Pulumi</PackageId>"; done=1 }' \
+				"$$csproj" > "$$csproj.tmp" && mv "$$csproj.tmp" "$$csproj"; \
+		fi
 	@touch $@
 
 build_dotnet: .make/build_dotnet

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,7 @@ schema: .make/schema
 		'| .language.python.packageName = "pulumi_deltastream"' \
 		'| .language.python.respectSchemaVersion = true' \
 		'| .language.python.pyproject.enabled = true' \
-		'| .language.csharp.packageName = "Pulumi.DeltaStream"' \
-		'| .language.csharp.rootNamespace = "Pulumi"' \
+		'| .language.csharp.packageName = "DeltaStream.Pulumi"' \
 		'| .language.csharp.respectSchemaVersion = true' \
 		'| .language.java.basePackage = "io.deltastream.pulumi.deltastream"' \
 		'| .language.java.buildFiles = "gradle"' \
@@ -199,6 +198,14 @@ generate_dotnet: .make/generate_dotnet
 	echo "$(PROVIDER_VERSION)" > sdk/dotnet/version.txt
 	printf "module fake_dotnet_module // Exclude from Go tools\n\ngo 1.21\n" \
 		> sdk/dotnet/go.mod
+	# The codegen'd .csproj derives its NuGet PackageId from the C# root
+	# namespace/filename, not from language.csharp.packageName above, so pin
+	# it explicitly here to avoid publishing under the reserved "Pulumi.*"
+	# NuGet ID prefix (owned by pulumi-bot).
+	@csproj=$$(find sdk/dotnet -maxdepth 1 -name '*.csproj'); \
+		grep -q '<PackageId>' "$$csproj" || \
+		sed -i.bak 's#<GeneratePackageOnBuild>true</GeneratePackageOnBuild>#<GeneratePackageOnBuild>true</GeneratePackageOnBuild>\n    <PackageId>DeltaStream.Pulumi</PackageId>#' "$$csproj" && \
+		rm -f "$$csproj.bak"
 	@touch $@
 
 build_dotnet: .make/build_dotnet

--- a/specs/004-multi-language-provider-build/contracts/github-actions-workflows.md
+++ b/specs/004-multi-language-provider-build/contracts/github-actions-workflows.md
@@ -146,7 +146,7 @@ Runs `make lint` against `provider/` Go code. Fails if any golangci-lint violati
 1. Creates GitHub Release at `v<version>` with tarballs, checksums, schema
 2. Publishes npm package `@deltastream/pulumi-deltastream@<version>`
 3. Publishes PyPI package `pulumi-deltastream==<version>`
-4. Publishes NuGet package `Pulumi.DeltaStream <version>`
+4. Publishes NuGet package `DeltaStream.Pulumi <version>`
 5. Tags Go SDK commit via `pulumi/publish-go-sdk-action`
 
 ---

--- a/specs/004-multi-language-provider-build/data-model.md
+++ b/specs/004-multi-language-provider-build/data-model.md
@@ -79,7 +79,7 @@ Each language SDK is generated from `schema.json` and published to the correspon
 |---|---|---|---|---|
 | TypeScript/Node | `pulumi package gen-sdk --language nodejs` | npm | `@deltastream/pulumi-deltastream` | `sdk/nodejs/` |
 | Python | `pulumi package gen-sdk --language python` | PyPI | `pulumi-deltastream` | `sdk/python/` |
-| .NET/C# | `pulumi package gen-sdk --language dotnet` | NuGet | `Pulumi.DeltaStream` | `sdk/dotnet/` |
+| .NET/C# | `pulumi package gen-sdk --language dotnet` | NuGet | `DeltaStream.Pulumi` | `sdk/dotnet/` |
 | Go | `pulumi package gen-sdk --language go` | Go module (git tag) | `github.com/deltastreaminc/pulumi-deltastream/sdk/go/pulumi-deltastream` | `sdk/go/` |
 | Java | `pulumi package gen-sdk --language java` | Maven Central (deferred) | `io.deltastream:pulumi-deltastream` | `sdk/java/` |
 
@@ -100,11 +100,13 @@ Each language SDK is generated from `schema.json` and published to the correspon
 | `logoUrl` | `https://raw.githubusercontent.com/.../deltastream-logo.png` |
 | `keywords` | `["pulumi", "deltastream", "category/database", "kind/native"]` |
 | `pluginDownloadURL` | `"github://api.github.com/deltastreaminc"` |
-| `language.csharp.packageName` | `"Pulumi.DeltaStream"` |
+| `language.csharp.packageName` | `"DeltaStream.Pulumi"` (see note below) |
 | `language.java.basePackage` | `"io.deltastream.pulumi.deltastream"` |
 | `language.python.packageName` | `"pulumi_deltastream"` |
 | `language.nodejs.packageName` | `"@deltastream/pulumi-deltastream"` |
 | `language.go.importBasePath` | `"github.com/deltastreaminc/pulumi-deltastream/sdk/go/pulumi-deltastream"` |
+
+**Note on `language.csharp.packageName`**: this schema field is documentation/metadata only — testing showed `pulumi package gen-sdk --language dotnet` does not use it to set the NuGet `PackageId`. The actual published package ID is pinned via a `Makefile` post-processing step that injects `<PackageId>DeltaStream.Pulumi</PackageId>` directly into the generated `.csproj` after codegen runs (avoids the reserved `Pulumi.*` NuGet ID prefix owned by `pulumi-bot`).
 
 ---
 

--- a/specs/004-multi-language-provider-build/plan.md
+++ b/specs/004-multi-language-provider-build/plan.md
@@ -70,7 +70,7 @@ $(PULUMI) package get-schema .make/$(PROVIDER) \
 - `logoUrl`
 - `keywords`
 - `displayName`
-- `language.csharp.packageName`, `language.csharp.rootNamespace`
+- `language.csharp.packageName`
 - `language.java.*`
 - `language.python.packageName`
 
@@ -162,8 +162,7 @@ $(PULUMI) package get-schema .make/$(PROVIDER) \
         | .language.python.packageName = "pulumi_deltastream"
         | .language.python.respectSchemaVersion = true
         | .language.python.pyproject.enabled = true
-        | .language.csharp.packageName = "Pulumi.DeltaStream"
-        | .language.csharp.rootNamespace = "Pulumi"
+        | .language.csharp.packageName = "DeltaStream.Pulumi"
         | .language.csharp.respectSchemaVersion = true
         | .language.java.basePackage = "io.deltastream.pulumi.deltastream"
         | .language.java.buildFiles = "gradle"
@@ -171,6 +170,8 @@ $(PULUMI) package get-schema .make/$(PROVIDER) \
         | .language.java.dependencies["com.pulumi:pulumi"] = "0.10.0"' \
   > $(SCHEMA_FILE)
 ```
+
+> **Note**: `language.csharp.packageName` is documentation/metadata only. `pulumi package gen-sdk --language dotnet` derives the generated `.csproj`'s NuGet `PackageId` from the C# root namespace/filename, not from this field, and always appends the module name (`Deltastream`) — there is no schema-only way to produce a clean `DeltaStream.Pulumi.csproj`. The `generate_dotnet` Makefile target therefore includes an additional post-processing step that injects `<PackageId>DeltaStream.Pulumi</PackageId>` directly into the generated `.csproj` after `gen-sdk` runs. This avoids publishing under the reserved `Pulumi.*` NuGet ID prefix (owned by the `pulumi-bot` account) — an issue discovered when the initially-chosen `Pulumi.DeltaStream` name repeatedly failed to publish (nuget.org rejects new packages matching a reserved prefix that the publishing account does not own).
 
 ### T-002: Add DeltaStream Logo
 
@@ -197,7 +198,7 @@ $(PULUMI) package get-schema .make/$(PROVIDER) \
 
 `publish.yml` uses `NuGet/login@v1` (OIDC token exchange) instead of a stored API key. The temporary key is valid for 1 hour and is obtained at workflow runtime.
 
-**One-time setup on nuget.org** (requires nuget.org account ownership of `Pulumi.DeltaStream`):
+**One-time setup on nuget.org** (requires nuget.org account ownership of `DeltaStream.Pulumi`):
 
 1. Log into **nuget.org**
 2. Navigate to your username → **Trusted Publishing**
@@ -206,7 +207,7 @@ $(PULUMI) package get-schema .make/$(PROVIDER) \
    - **Repository**: `pulumi-deltastream`
    - **Workflow File**: `publish.yml` *(filename only — do not include `.github/workflows/` prefix)*
    - **Environment**: *(leave empty)*
-4. Add a single repository secret: `NUGET_USERNAME` — set to the nuget.org username (profile name, not email) that owns the `Pulumi.DeltaStream` package
+4. Add a single repository secret: `NUGET_USERNAME` — set to the nuget.org username (profile name, not email) that owns the `DeltaStream.Pulumi` package
 
 > The `NUGET_API_TOKEN` secret is **not needed**. The `NuGet/login@v1` action exchanges the GitHub OIDC token for a short-lived key at publish time. The `publish_sdk` job has `id-token: write` permission for this purpose.
 

--- a/specs/004-multi-language-provider-build/research.md
+++ b/specs/004-multi-language-provider-build/research.md
@@ -102,16 +102,30 @@ This research phase consolidates findings from prior analysis sessions on pulumi
 
 ## Decision 7: Schema Metadata for Pulumi Registry
 
-**Decision**: Add `publisher`, `logoUrl`, `keywords`, `description` to `schema.json`. Add complete language blocks for `csharp` (packageName: `Pulumi.DeltaStream`), `java` (basePackage: `io.deltastream.pulumi.deltastream`), and `python` (packageName: `pulumi_deltastream`).
+**Decision**: Add `publisher`, `logoUrl`, `keywords`, `description` to `schema.json`. Add complete language blocks for `csharp` (packageName: `DeltaStream.Pulumi`), `java` (basePackage: `io.deltastream.pulumi.deltastream`), and `python` (packageName: `pulumi_deltastream`).
 
 **Rationale**:
 - Pulumi Registry listing requires these fields per the [publishing guide](https://www.pulumi.com/docs/iac/guides/building-extending/packages/publishing-packages/).
-- The NuGet package name `Pulumi.DeltaStream` follows Pulumi's own convention (e.g., `Pulumi.Aws`, `Pulumi.Azure`).
+- The NuGet package name `DeltaStream.Pulumi` avoids the `Pulumi.*` NuGet ID prefix, which is reserved on nuget.org for the `pulumi-bot` account (used by Pulumi Corp's own providers, e.g. `Pulumi.Aws`, `Pulumi.Azure`). Any new package submitted under a reserved prefix by a non-owning account is rejected by nuget.org with a 409 response; this was discovered when the initial `Pulumi.DeltaStream` package repeatedly failed to publish in CI (see Decision 7a below).
 - The Python package name `pulumi_deltastream` follows PyPI snake_case convention.
 - `keywords` array must include `category/database` and `kind/native` for correct registry classification.
 
 **Alternatives considered**:
-- `DeltaStream.Pulumi` (org-first naming): Rejected in favour of `Pulumi.DeltaStream` to match the established Pulumi ecosystem convention users expect.
+- `Pulumi.DeltaStream` (Pulumi ecosystem naming convention, e.g. `Pulumi.Aws`, `Pulumi.Azure`): Initially chosen to match the established convention, but rejected after discovering that `Pulumi.*` is a reserved NuGet ID prefix owned by `pulumi-bot`; nuget.org rejects any new package submission under this prefix from a different account.
+
+---
+
+## Decision 7a: NuGet Package ID vs. `language.csharp.packageName` schema field
+
+**Decision**: Set `language.csharp.packageName` to `DeltaStream.Pulumi` for documentation/metadata purposes, but explicitly pin the actual NuGet `PackageId` in the generated `.csproj` via a `Makefile` post-processing step after `pulumi package gen-sdk --language dotnet` runs.
+
+**Rationale**:
+- Testing with `pulumi package gen-sdk` locally showed that the codegen's `language.csharp.packageName` schema field does **not** control the published NuGet package ID. The actual ID is derived from the generated `.csproj` filename, which in turn is derived from `language.csharp.rootNamespace` + the capitalized schema/module name (`Deltastream`) — always appending the module suffix, with no schema-only way to produce a clean two-segment name like `DeltaStream.Pulumi`.
+- The robust fix is to explicitly set `<PackageId>DeltaStream.Pulumi</PackageId>` in the `.csproj` after generation, which is the standard MSBuild/NuGet mechanism for pinning a package ID independent of assembly name/namespace.
+- `language.csharp.rootNamespace` is left unset (default), so the C# namespace remains whatever codegen derives (`Deltastream.Deltastream`) — this is only a source-code namespace and has no effect on the published package ID once `<PackageId>` is pinned.
+
+**Alternatives considered**:
+- Setting only `language.csharp.rootNamespace`/`packageName` in the schema and hoping the codegen'd filename matches: Rejected — verified empirically that no combination of `rootNamespace`/`packageName` produces a clean `DeltaStream.Pulumi.csproj` without the module-name suffix.
 
 ---
 
@@ -143,7 +157,7 @@ All questions from spec were pre-resolved via prior research sessions:
 
 | Question | Resolution |
 |---|---|
-| .NET package name | `Pulumi.DeltaStream` (Pulumi convention) |
+| .NET package name | `DeltaStream.Pulumi` (avoids reserved `Pulumi.*` NuGet ID prefix) |
 | Java in default build | Yes, included in full build pipeline |
 | Devcontainer approach | Explicit Dockerfile (thin, mise-bootstrapped) |
 | Windows binaries | No, Linux + macOS only (consistent with existing matrix) |

--- a/specs/004-multi-language-provider-build/spec.md
+++ b/specs/004-multi-language-provider-build/spec.md
@@ -55,7 +55,7 @@ A maintainer pushes a version tag (e.g., `v1.2.0`). The release pipeline cross-c
 **Acceptance Scenarios**:
 
 1. **Given** a maintainer pushes a `v*.*.*` tag, **When** the release workflow completes, **Then** a GitHub Release exists containing provider tarballs for linux-amd64, linux-arm64, darwin-amd64, and darwin-arm64, plus a SHA256 checksums file and `schema.json`.
-2. **Given** a successful release build, **When** the publish step runs, **Then** `@deltastream/pulumi-deltastream` is available on npm, `pulumi-deltastream` is available on PyPI, `Pulumi.DeltaStream` is available on NuGet, and the Go SDK is tagged in the repository.
+2. **Given** a successful release build, **When** the publish step runs, **Then** `@deltastream/pulumi-deltastream` is available on npm, `pulumi-deltastream` is available on PyPI, `DeltaStream.Pulumi` is available on NuGet, and the Go SDK is tagged in the repository.
 3. **Given** a version tag containing a hyphen (e.g., `v1.2.0-alpha.1`), **When** the release workflow runs, **Then** it is treated as a prerelease and the GitHub Release is created as a draft rather than a public release.
 4. **Given** a completed release publication, **When** the verify job runs, **Then** a smoke test successfully installs and imports the Node.js SDK from npm using the published version.
 
@@ -101,7 +101,7 @@ The DeltaStream provider is listed in the public Pulumi Registry with a complete
 - **FR-011**: The `prerequisites.yml` workflow MUST run `make test_provider` (unit tests) before SDK generation and post a schema diff comment on pull requests.
 - **FR-012**: The `publish.yml` workflow MUST publish all five language SDKs using `pulumi/pulumi-package-publisher` with `sdk: all`, publish the Go SDK via `pulumi/publish-go-sdk-action`, and create a GitHub Release with provider tarballs, checksums, and `schema.json`.
 - **FR-013**: The `verify-release.yml` workflow MUST run smoke tests for the Node.js and Python SDKs after publication to confirm the published packages are importable.
-- **FR-014**: The `schema.json` MUST include complete language metadata for all five languages: nodejs (`packageName`), python (`pyproject`), dotnet (`packageName`, `rootNamespace`), go (`importBasePath`), and java (`basePackage`).
+- **FR-014**: The `schema.json` MUST include complete language metadata for all five languages: nodejs (`packageName`), python (`pyproject`), dotnet (`packageName`), go (`importBasePath`), and java (`basePackage`).
 - **FR-015**: Fork PRs MUST trigger the build and lint jobs but NOT the integration test job (which requires secrets).
 - **FR-016**: The `.gitignore` MUST NOT exclude `.config/` (required for mise configuration) and MUST exclude generated SDK directories `sdk/dotnet/`, `sdk/java/`.
 - **FR-017**: The repository MUST contain `docs/_index.md` and `docs/installation-configuration.md` suitable for submission to the Pulumi Registry.
@@ -122,7 +122,7 @@ The DeltaStream provider is listed in the public Pulumi Registry with a complete
 - **SC-001**: A developer with only Docker and VS Code installed can go from fresh clone to a passing `make build` (all five language SDKs) in under 15 minutes on a standard laptop.
 - **SC-002**: A pull request CI run completes all five language SDK builds in parallel and reports results in under 20 minutes.
 - **SC-003**: A full release pipeline (build all platforms + publish all SDKs) completes end-to-end in under 30 minutes from tag push to GitHub Release creation.
-- **SC-004**: All five language SDKs (`@deltastream/pulumi-deltastream` on npm, `pulumi-deltastream` on PyPI, `Pulumi.DeltaStream` on NuGet, Go module, Java on Maven) are installable by users using standard package manager commands within 10 minutes of a release completing.
+- **SC-004**: All five language SDKs (`@deltastream/pulumi-deltastream` on npm, `pulumi-deltastream` on PyPI, `DeltaStream.Pulumi` on NuGet, Go module, Java on Maven) are installable by users using standard package manager commands within 10 minutes of a release completing.
 - **SC-005**: The provider appears in the Pulumi Registry at `pulumi.com/registry/packages/deltastream` following a one-time registry PR submission.
 - **SC-006**: CI tool setup time is reduced by eliminating per-language setup actions — all tools installed via a single mise step with cache restoration.
 

--- a/specs/004-multi-language-provider-build/tasks.md
+++ b/specs/004-multi-language-provider-build/tasks.md
@@ -25,7 +25,7 @@ description: "Tasks for feature 004-multi-language-provider-build"
 
 **Status**: ✅ Already applied during the planning phase. Verify correctness below.
 
-- [x] T001 Verify `make schema` jq pipeline in `Makefile` (line `.make/schema` target) injects all 13 metadata fields: `displayName`, `description`, `publisher`, `logoUrl`, `keywords`, `language.go.*`, `language.nodejs.packageName`, `language.python.packageName`, `language.python.pyproject`, `language.csharp.packageName`, `language.csharp.rootNamespace`, `language.java.basePackage`, `language.java.buildFiles`
+- [x] T001 Verify `make schema` jq pipeline in `Makefile` (line `.make/schema` target) injects all 12 metadata fields: `displayName`, `description`, `publisher`, `logoUrl`, `keywords`, `language.go.*`, `language.nodejs.packageName`, `language.python.packageName`, `language.python.pyproject`, `language.csharp.packageName`, `language.java.basePackage`, `language.java.buildFiles`
 - [x] T002 Run `python3 -c "import json; d=json.load(open('schema.json')); assert d.get('publisher') == 'DeltaStream Inc.', f'Missing: {d.get(\"publisher\")}'; print('schema.json metadata OK')"` at repo root to confirm current `schema.json` has the metadata (note: regeneration requires `pulumi` CLI + built provider)
 
 ---
@@ -110,7 +110,7 @@ description: "Tasks for feature 004-multi-language-provider-build"
 - [ ] T032 [US3] Confirm `publish` job creates a draft GitHub Release with all 4 tarballs, checksums file, and `schema.json` attached
 - [ ] T033 [US3] Confirm `publish_sdk` job publishes `@deltastream/pulumi-deltastream@1.0.0-rc.1` to npm: `npm view @deltastream/pulumi-deltastream@1.0.0-rc.1 version`
 - [ ] T034 [US3] Confirm `publish_sdk` job publishes `pulumi-deltastream==1.0.0-rc.1` to PyPI: `pip index versions pulumi-deltastream`
-- [ ] T035 [US3] Confirm `publish_sdk` job publishes `Pulumi.DeltaStream 1.0.0-rc.1` to NuGet via OIDC Trusted Publishing (no API key stored)
+- [ ] T035 [US3] Confirm `publish_sdk` job publishes `DeltaStream.Pulumi 1.0.0-rc.1` to NuGet via OIDC Trusted Publishing (no API key stored)
 - [ ] T036 [US3] Confirm `verify` job smoke tests pass: Node.js `require('@deltastream/pulumi-deltastream')` and Python `import pulumi_deltastream` both succeed
 - [ ] T037 [US3] Confirm Go SDK is tagged by `pulumi/publish-go-sdk-action`: check that a `sdk/v1.0.0-rc.1` tag exists on the repository after the publish job
 


### PR DESCRIPTION
## Problem

Every release's `publish_sdk` job silently failed to publish the NuGet package. Both `v1.0.0-rc.4` and `v1.0.0-rc.5` logs show:

```
Pushing Pulumi.Deltastream.1.0.0-rc.X.nupkg to 'https://www.nuget.org/api/v2/package'...
Package '.../Pulumi.Deltastream.1.0.0-rc.X.nupkg' already exists at feed '...'.
```

Despite the "already exists" message, the package was **never** published — `nuget.org/packages/Pulumi.Deltastream` returns 404 and the package doesn't appear in search. The real cause: `Pulumi.*` is a reserved NuGet ID prefix owned by the `pulumi-bot` account (Pulumi Corp's own providers — `Pulumi.Aws`, `Pulumi.Azure`, etc.). Any new package submission under a reserved prefix from a non-owning account is rejected by nuget.org with a 409, and `dotnet nuget push --skip-duplicate` treats that the same as a real duplicate, so the CI job reported green.
