### PR TITLE
fix: send Kafka store TLS CA cert via attachment instead of inline SQL

### DIFF
--- a/provider/store_kafka.go
+++ b/provider/store_kafka.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -25,6 +26,8 @@ import (
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 	"k8s.io/utils/ptr"
+
+	godeltastream "github.com/deltastreaminc/go-deltastream"
 )
 
 // KafkaInputs holds Kafka-specific properties for a store (split from store.go).
@@ -123,8 +126,8 @@ func storeKafkaCreate(ctx context.Context, conn *sql.Conn, input *StoreArgs) err
 		if err != nil {
 			return fmt.Errorf("failed reading tlsCaCertFile: %w", err)
 		}
-		esc := strings.ReplaceAll(string(content), "'", "''")
-		params["tls.ca_cert"] = fmt.Sprintf("'%s'", esc)
+		params["tls.ca_cert_file"] = "'@cacert'"
+		ctx = godeltastream.WithAttachment(ctx, "cacert", io.NopCloser(strings.NewReader(string(content))))
 	}
 	pairs := make([]string, 0, len(params))
 	for kkey, v := range params {
@@ -229,14 +232,14 @@ func storeKafkaUpdate(ctx context.Context, req infer.UpdateRequest[StoreArgs, St
 	}
 	if (curr.TlsCaCertFile == nil) != (old.TlsCaCertFile == nil) || (curr.TlsCaCertFile != nil && old.TlsCaCertFile != nil && *curr.TlsCaCertFile != *old.TlsCaCertFile) {
 		if curr.TlsCaCertFile == nil {
-			changes["tls.ca_cert"] = "NULL"
+			changes["tls.ca_cert_file"] = "NULL"
 		} else if curr.TlsDisabled == nil || !*curr.TlsDisabled {
 			content, err := os.ReadFile(*curr.TlsCaCertFile)
 			if err != nil {
 				return infer.UpdateResponse[StoreState]{}, fmt.Errorf("failed reading tlsCaCertFile: %w", err)
 			}
-			esc := strings.ReplaceAll(string(content), "'", "''")
-			changes["tls.ca_cert"] = fmt.Sprintf("'%s'", esc)
+			changes["tls.ca_cert_file"] = "'@cacert'"
+			ctx = godeltastream.WithAttachment(ctx, "cacert", io.NopCloser(strings.NewReader(string(content))))
 		}
 	}
 	if len(changes) == 0 {


### PR DESCRIPTION
## Problem

Creating or updating a Kafka store with a CA certificate fails with:

```
error: failed updating store: parse error: line 1:197 no viable alternative
at input ''tls.ca_cert'' (SQLState: 42601)
```

## Root cause

`storeKafkaCreate` and `storeKafkaUpdate` in `provider/store_kafka.go` read the
CA cert file and inlined the raw (potentially multi-line) PEM content directly
into the SQL statement under an undocumented parameter name, `tls.ca_cert`:

```go
esc := strings.ReplaceAll(string(content), "'", "''")
params["tls.ca_cert"] = fmt.Sprintf("'%s'", esc)
```

The DeltaStream SQL grammar cannot parse a multi-line string literal embedded
this way, so the parser fails.

The documented parameter is `tls.ca_cert_file`, whose value is a symbolic file
reference (e.g. `'@name'`), with the actual file content delivered
out-of-band as a request attachment — the same mechanism already used by the
Snowflake store for its client key file (`snowflake.client.key_file` /
`@keyfile`).

## Fix

- Use `tls.ca_cert_file = '@cacert'` instead of inlining `tls.ca_cert`.
- Attach the certificate content via `godeltastream.WithAttachment(ctx, "cacert", ...)`.
- Applied consistently to both create and update paths, including the
  `NULL`-clearing behavior when the cert is removed.

No schema/SDK changes are needed — the `tlsCaCertFile` Pulumi input remains a
local file path.

## Testing

- `go build ./...`
- `go vet ./...`
- `go test ./provider/...`

All pass.